### PR TITLE
added parsing for xml or tab-delimited results from MWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ npm install mws-simple
 ### List Orders (open and created in last 24 hours):
 ``` javascript
 let mws = require('mws-simple')({
-  accessKeyId: YOUR ACCESS KEY
-  secretAccessId: YOUR ACCESS KEY
+  accessKeyId: YOUR ACCESS KEY,
+  secretAccessKey: YOUR ACCESS KEY,
   merchantId: YOUR MERCHANT ID
 });
 

--- a/mws-simple.js
+++ b/mws-simple.js
@@ -94,7 +94,7 @@ Client.prototype.request = function(requestData, callback) {
   request.post(options, function (error, response, body) {
     if (error) callback(error);
 
-    if (response.headers['content-type'] == 'text/xml') {
+    if (response.headers.hasOwnProperty('content-type') && response.headers['content-type'].startsWith('text/xml')) {
       // xml2js
       xmlParser(body, function (err, result) {
         callback(err, result);

--- a/mws-simple.js
+++ b/mws-simple.js
@@ -5,7 +5,7 @@
 let crypto = require('crypto');
 let request = require('request');
 let xmlParser = require('xml2js').parseString;
-let tabParser = require('node-csv-parse');
+let tabParser = require('csv-parse');
 let qs = require('query-string');
 
 // Client is the class constructor
@@ -101,8 +101,11 @@ Client.prototype.request = function(requestData, callback) {
       });
     } else {
       // currently only other type of data returned is tab-delimited text
-      var resultArr = tabParser(body, '\t').asObjects();
-      callback(null, resultArr);
+      tabParser(body, {
+        delimiter:'\t',
+        columns: true,
+        relax: true
+      }, callback);
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "nodejs Amazon MWS API in 100 lines of code",
   "main": "mws-simple.js",
   "dependencies": {
-    "node-csv-parse": "^1.2.0",
+    "csv-parse": "^1.1.1",
     "query-string": "^4.1.0",
     "request": "^2.72.0",
     "xml2js": "^0.4.16"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "nodejs Amazon MWS API in 100 lines of code",
   "main": "mws-simple.js",
   "dependencies": {
+    "node-csv-parse": "^1.2.0",
     "query-string": "^4.1.0",
     "request": "^2.72.0",
     "xml2js": "^0.4.16"


### PR DESCRIPTION
I'm using the /Reports/ endpoint on MWS and some actions return tab-delimited data. The current version crashes because of that.

I added in a simple check in the header of the results for the content type. If it is text/xml then it goes down the path that was already there but otherwise it tries to parse as a tab-delimited file and returns that back. I'm using the node-csv-parse module to parse and it works great.

Also tweaked the example in the README, it had a typo and some missing commas :)
