### PR TITLE
Added return on error in request.post so it doesn't crash if there is an error

### DIFF
--- a/mws-simple.js
+++ b/mws-simple.js
@@ -92,7 +92,7 @@ Client.prototype.request = function(requestData, callback) {
 
   // Make call to MWS
   request.post(options, function (error, response, body) {
-    if (error) callback(error);
+    if (error) return callback(error);
 
     if (response.headers.hasOwnProperty('content-type') && response.headers['content-type'].startsWith('text/xml')) {
       // xml2js

--- a/mws-simple.js
+++ b/mws-simple.js
@@ -7,6 +7,7 @@ let request = require('request');
 let xmlParser = require('xml2js').parseString;
 let tabParser = require('csv-parse');
 let qs = require('query-string');
+let fs = require('fs');
 
 // Client is the class constructor
 module.exports = Client;
@@ -100,6 +101,10 @@ Client.prototype.request = function(requestData, callback) {
         callback(err, result);
       });
     } else {
+			// fs.writeFile('./inventory-health.csv', body, (err) => {
+			// 	if (err) return console.log(err)
+			// 	console.log('wrote csv file');
+			// });
       // currently only other type of data returned is tab-delimited text
       tabParser(body, {
         delimiter:'\t',


### PR DESCRIPTION
If the network connection gets reset or there is some error in the request the current way most likely will bomb out because the following lines try to get information out of a potentially failed request. 

Because this is mws-**simple**, I figured the right philosophy would be to just stop when an error occurs and pass it back up rather than try and do something more involved with retrying, etc.
