### PR TITLE
Handle GetFeedSubmissionResult response.

### DIFF
--- a/mws-simple.js
+++ b/mws-simple.js
@@ -99,7 +99,11 @@ Client.prototype.request = function(requestData, callback) {
       xmlParser(body, function (err, result) {
         callback(err, result);
       });
-    } else {
+    } else if( typeof body === 'string' && body.startsWith('Feed Processing Summary') ){
+      // Feed Processing Summaries are pure text data.
+	  // They are not tab-delimited.
+	  callback(undefined, body);
+    }} else {
       // currently only other type of data returned is tab-delimited text
       tabParser(body, {
         delimiter:'\t',

--- a/mws-simple.js
+++ b/mws-simple.js
@@ -101,8 +101,8 @@ Client.prototype.request = function(requestData, callback) {
       });
     } else if( typeof body === 'string' && body.startsWith('Feed Processing Summary') ){
       // Feed Processing Summaries are pure text data.
-	  // They are not tab-delimited.
-	  callback(undefined, body);
+      // They are not tab-delimited.
+      callback(undefined, body);
     }} else {
       // currently only other type of data returned is tab-delimited text
       tabParser(body, {

--- a/mws-simple.js
+++ b/mws-simple.js
@@ -103,7 +103,7 @@ Client.prototype.request = function(requestData, callback) {
       // Feed Processing Summaries are pure text data.
       // They are not tab-delimited.
       callback(undefined, body);
-    }} else {
+    } else {
       // currently only other type of data returned is tab-delimited text
       tabParser(body, {
         delimiter:'\t',


### PR DESCRIPTION
Feed Processing Summary data (returned by the GetFeedSubmissionResult call) are pure, unstructered text data. Using the tabParser on them leads to an error. They are now returned as they are.